### PR TITLE
fix: build for tags version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Build Binary
 
 on:
   push:
-    branches:
-      - main
     tags:
       # Regex for a version number such as 0.2.1
       - "[0-9]+.[0-9]+.[0-9]+"


### PR DESCRIPTION
/usr/bin/git checkout --progress --force refs/tags/0.0.10
  env:
    VERSION: refs/heads/main
cannot create directory ‘anychain-bitcoin-cli-refs/heads/main-x86_64-unknown-linux-musl’: No such file or directory